### PR TITLE
Implement using an ECPrivateKey supplier for NotoryToolClient

### DIFF
--- a/lib/src/main/kotlin/ca/ewert/notarytoolkotlin/NotaryToolClient.kt
+++ b/lib/src/main/kotlin/ca/ewert/notarytoolkotlin/NotaryToolClient.kt
@@ -2,6 +2,7 @@ package ca.ewert.notarytoolkotlin
 
 import ca.ewert.notarytoolkotlin.NotaryToolError.UserInputError.JsonWebTokenError
 import ca.ewert.notarytoolkotlin.authentication.JsonWebToken
+import ca.ewert.notarytoolkotlin.authentication.createPrivateKey
 import ca.ewert.notarytoolkotlin.i18n.ErrorStringsResource
 import ca.ewert.notarytoolkotlin.json.notaryapi.ErrorResponseJson
 import ca.ewert.notarytoolkotlin.json.notaryapi.NewSubmissionRequestJson
@@ -46,6 +47,7 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectResponse
 import java.nio.file.Path
+import java.security.interfaces.ECKey
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import kotlin.io.path.absolutePathString
@@ -75,7 +77,7 @@ private val log = KotlinLogging.logger {}
  * testing with MockWebServer
  * @property privateKeyId The private key ID, provided by Apple.
  * @property issuerId The issuer ID, provided by Apple.
- * @property privateKeyFile The Private Key file `.p8` provided by Apple
+ * @property privateKeyProvider A function that creates an [ECKey], using the private key file (`.p8`) provided by Apple.
  * @property tokenLifetime Lifetime of the token used for Authentication. It should be less than 20 minutes,
  * or request will be rejected by Apple. The default value is **15 minutes**
  * @property baseUrlString The base url of Apple's Notary Web API. The default value is:
@@ -87,12 +89,42 @@ private val log = KotlinLogging.logger {}
 class NotaryToolClient internal constructor(
   val privateKeyId: String,
   val issuerId: String,
-  val privateKeyFile: Path,
+  val privateKeyProvider: () -> Result<ECKey, JsonWebTokenError>,
   val tokenLifetime: Duration = Duration.of(15, ChronoUnit.MINUTES),
   private val baseUrlString: String,
   val connectTimeout: Duration = Duration.of(10, ChronoUnit.SECONDS),
   val userAgent: String = USER_AGENT_VALUE,
 ) {
+
+  /**
+   * Creates a [NotaryToolClient] that can be used to make requests to Apple's Notary API Web Service.
+   * This constructor allows setting the [baseUrlString], and is used for unit testing, using a mock webserver.
+   *
+   * @param privateKeyId The private key ID, provided by Apple.
+   * @param issuerId The issuer ID, provided by Apple.
+   * @param privateKeyFile The Private Key file `.p8` provided by Apple
+   * @param tokenLifetime Lifetime of the token used for Authentication. It should be less than 20 minutes,
+   * or request will be rejected by Apple. The default value is **15 minutes**
+   * @param connectTimeout Sets the default *connect timeout* for the connection. The default value is **10 seconds**
+   * @param userAgent Custom `"User-Agent"` to use when sending requests. The default is `notarytool-kotlin/x.y.z`
+   */
+  internal constructor(
+    privateKeyId: String,
+    issuerId: String,
+    privateKeyFile: Path,
+    tokenLifetime: Duration = Duration.of(15, ChronoUnit.MINUTES),
+    baseUrlString: String,
+    connectTimeout: Duration = Duration.of(10, ChronoUnit.SECONDS),
+    userAgent: String = USER_AGENT_VALUE,
+  ) : this(
+    privateKeyId = privateKeyId,
+    issuerId = issuerId,
+    privateKeyProvider = { createPrivateKey(privateKeyFile) },
+    tokenLifetime = tokenLifetime,
+    baseUrlString = baseUrlString,
+    connectTimeout = connectTimeout,
+    userAgent = userAgent,
+  )
 
   /**
    * Creates a [NotaryToolClient] that can be used to make requests to Apple's Notary API Web Service.
@@ -115,7 +147,35 @@ class NotaryToolClient internal constructor(
   ) : this(
     privateKeyId = privateKeyId,
     issuerId = issuerId,
-    privateKeyFile = privateKeyFile,
+    privateKeyProvider = { createPrivateKey(privateKeyFile) },
+    tokenLifetime = tokenLifetime,
+    baseUrlString = BASE_URL_STRING,
+    connectTimeout = connectTimeout,
+    userAgent = userAgent,
+  )
+
+  /**
+   * Creates a [NotaryToolClient] that can be used to make requests to Apple's Notary API Web Service.
+   *
+   * @param privateKeyId The private key ID, provided by Apple.
+   * @param issuerId The issuer ID, provided by Apple.
+   * @param privateKeyProvider A function that creates an [ECKey], using the private key file (`.p8`) provided by Apple.
+   * @param tokenLifetime Lifetime of the token used for Authentication. It should be less than 20 minutes,
+   * or request will be rejected by Apple. The default value is **15 minutes**
+   * @param connectTimeout Sets the default *connect timeout* for the connection. The default value is **10 seconds**
+   * @param userAgent Custom `"User-Agent"` to use when sending requests. The default is `notarytool-kotlin/x.y.z`
+   */
+  constructor(
+    privateKeyId: String,
+    issuerId: String,
+    privateKeyProvider: () -> Result<ECKey, JsonWebTokenError>,
+    tokenLifetime: Duration = Duration.of(15, ChronoUnit.MINUTES),
+    connectTimeout: Duration = Duration.of(10, ChronoUnit.SECONDS),
+    userAgent: String = USER_AGENT_VALUE,
+  ) : this(
+    privateKeyId = privateKeyId,
+    issuerId = issuerId,
+    privateKeyProvider = privateKeyProvider,
     tokenLifetime = tokenLifetime,
     baseUrlString = BASE_URL_STRING,
     connectTimeout = connectTimeout,
@@ -183,7 +243,7 @@ class NotaryToolClient internal constructor(
     JsonWebToken.create(
       privateKeyId = privateKeyId,
       issuerId = issuerId,
-      privateKeyFile = privateKeyFile,
+      privateKeyProvider = privateKeyProvider,
       tokenLifetime = tokenLifetime,
     )
 

--- a/lib/src/main/kotlin/ca/ewert/notarytoolkotlin/NotaryToolClient.kt
+++ b/lib/src/main/kotlin/ca/ewert/notarytoolkotlin/NotaryToolClient.kt
@@ -47,7 +47,7 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectResponse
 import java.nio.file.Path
-import java.security.interfaces.ECKey
+import java.security.interfaces.ECPrivateKey
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import kotlin.io.path.absolutePathString
@@ -77,7 +77,7 @@ private val log = KotlinLogging.logger {}
  * testing with MockWebServer
  * @property privateKeyId The private key ID, provided by Apple.
  * @property issuerId The issuer ID, provided by Apple.
- * @property privateKeyProvider A function that creates an [ECKey], using the private key file (`.p8`) provided by Apple.
+ * @property privateKeyProvider A function that creates an [ECPrivateKey], using the private key file (`.p8`) provided by Apple.
  * @property tokenLifetime Lifetime of the token used for Authentication. It should be less than 20 minutes,
  * or request will be rejected by Apple. The default value is **15 minutes**
  * @property baseUrlString The base url of Apple's Notary Web API. The default value is:
@@ -89,7 +89,7 @@ private val log = KotlinLogging.logger {}
 class NotaryToolClient internal constructor(
   val privateKeyId: String,
   val issuerId: String,
-  val privateKeyProvider: () -> Result<ECKey, JsonWebTokenError>,
+  val privateKeyProvider: () -> Result<ECPrivateKey, JsonWebTokenError>,
   val tokenLifetime: Duration = Duration.of(15, ChronoUnit.MINUTES),
   private val baseUrlString: String,
   val connectTimeout: Duration = Duration.of(10, ChronoUnit.SECONDS),
@@ -159,7 +159,7 @@ class NotaryToolClient internal constructor(
    *
    * @param privateKeyId The private key ID, provided by Apple.
    * @param issuerId The issuer ID, provided by Apple.
-   * @param privateKeyProvider A function that creates an [ECKey], using the private key file (`.p8`) provided by Apple.
+   * @param privateKeyProvider A function that creates an [ECPrivateKey], using the private key file (`.p8`) provided by Apple.
    * @param tokenLifetime Lifetime of the token used for Authentication. It should be less than 20 minutes,
    * or request will be rejected by Apple. The default value is **15 minutes**
    * @param connectTimeout Sets the default *connect timeout* for the connection. The default value is **10 seconds**
@@ -168,7 +168,7 @@ class NotaryToolClient internal constructor(
   constructor(
     privateKeyId: String,
     issuerId: String,
-    privateKeyProvider: () -> Result<ECKey, JsonWebTokenError>,
+    privateKeyProvider: () -> Result<ECPrivateKey, JsonWebTokenError>,
     tokenLifetime: Duration = Duration.of(15, ChronoUnit.MINUTES),
     connectTimeout: Duration = Duration.of(10, ChronoUnit.SECONDS),
     userAgent: String = USER_AGENT_VALUE,

--- a/lib/src/main/kotlin/ca/ewert/notarytoolkotlin/authentication/JsonWebToken.kt
+++ b/lib/src/main/kotlin/ca/ewert/notarytoolkotlin/authentication/JsonWebToken.kt
@@ -10,7 +10,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.nio.charset.StandardCharsets
-import java.security.interfaces.ECKey
+import java.security.interfaces.ECPrivateKey
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
@@ -33,7 +33,7 @@ private val moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
  *
  * @property privateKeyId Apple private key ID
  * @property issuerId Apple Issuer ID
- * @property privateKeyProvider Function that provides an [ECKey], used in generating the jwt.
+ * @property privateKeyProvider Function that provides an [ECPrivateKey], used in generating the jwt.
  * @property tokenLifetime Lifetime of the token, should be less than 20 minutes
  *
  * @author vewert
@@ -41,7 +41,7 @@ private val moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
 internal class JsonWebToken private constructor(
   private val privateKeyId: String,
   private val issuerId: String,
-  private val privateKeyProvider: () -> Result<ECKey, JsonWebTokenError>,
+  private val privateKeyProvider: () -> Result<ECPrivateKey, JsonWebTokenError>,
   private val tokenLifetime: Duration = Duration.ofMinutes(15),
   _issuedAtTime: Instant,
   _expirationTime: Instant,
@@ -55,7 +55,7 @@ internal class JsonWebToken private constructor(
      *
      * @param privateKeyId Private Key ID, provided by Apple
      * @param issuerId Team Issuer ID provided by Apple
-     * @param privateKeyProvider Function that provides an [ECKey], used in generating the jwt.
+     * @param privateKeyProvider Function that provides an [ECPrivateKey], used in generating the jwt.
      * @param tokenLifetime Lifetime for the token, should be less than 20 minutes,
      * default value is 15 minutes
      *
@@ -65,7 +65,7 @@ internal class JsonWebToken private constructor(
     fun create(
       privateKeyId: String,
       issuerId: String,
-      privateKeyProvider: () -> Result<ECKey, JsonWebTokenError>,
+      privateKeyProvider: () -> Result<ECPrivateKey, JsonWebTokenError>,
       tokenLifetime: Duration = Duration.of(15, ChronoUnit.MINUTES),
     ): Result<JsonWebToken, JsonWebTokenError> {
       val issued = Instant.now()

--- a/lib/src/main/kotlin/ca/ewert/notarytoolkotlin/authentication/JsonWebToken.kt
+++ b/lib/src/main/kotlin/ca/ewert/notarytoolkotlin/authentication/JsonWebToken.kt
@@ -10,7 +10,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.nio.charset.StandardCharsets
-import java.nio.file.Path
+import java.security.interfaces.ECKey
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
@@ -33,7 +33,7 @@ private val moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
  *
  * @property privateKeyId Apple private key ID
  * @property issuerId Apple Issuer ID
- * @property privateKeyFile Private Key file `.p8` provided by Apple
+ * @property privateKeyProvider Function that provides an [ECKey], used in generating the jwt.
  * @property tokenLifetime Lifetime of the token, should be less than 20 minutes
  *
  * @author vewert
@@ -41,7 +41,7 @@ private val moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
 internal class JsonWebToken private constructor(
   private val privateKeyId: String,
   private val issuerId: String,
-  private val privateKeyFile: Path,
+  private val privateKeyProvider: () -> Result<ECKey, JsonWebTokenError>,
   private val tokenLifetime: Duration = Duration.ofMinutes(15),
   _issuedAtTime: Instant,
   _expirationTime: Instant,
@@ -54,8 +54,8 @@ internal class JsonWebToken private constructor(
      * a Result containing a [JsonWebToken] or a [JsonWebTokenError]
      *
      * @param privateKeyId Private Key ID, provided by Apple
-     * @param issuerId Team Issuer ID provided by Appple
-     * @param privateKeyFile Private Key file `.p8` provided by Apple
+     * @param issuerId Team Issuer ID provided by Apple
+     * @param privateKeyProvider Function that provides an [ECKey], used in generating the jwt.
      * @param tokenLifetime Lifetime for the token, should be less than 20 minutes,
      * default value is 15 minutes
      *
@@ -65,7 +65,7 @@ internal class JsonWebToken private constructor(
     fun create(
       privateKeyId: String,
       issuerId: String,
-      privateKeyFile: Path,
+      privateKeyProvider: () -> Result<ECKey, JsonWebTokenError>,
       tokenLifetime: Duration = Duration.of(15, ChronoUnit.MINUTES),
     ): Result<JsonWebToken, JsonWebTokenError> {
       val issued = Instant.now()
@@ -73,14 +73,14 @@ internal class JsonWebToken private constructor(
       return generateJwt(
         privateKeyId,
         issuerId,
-        privateKeyFile,
+        privateKeyProvider,
         issued,
         expiry,
       ).map { jwtString ->
         JsonWebToken(
           privateKeyId,
           issuerId,
-          privateKeyFile,
+          privateKeyProvider,
           tokenLifetime,
           issued,
           expiry,
@@ -165,7 +165,7 @@ internal class JsonWebToken private constructor(
   internal fun updateWebToken(): Result<Unit, JsonWebTokenError> {
     issuedAtTime = Instant.now()
     expirationTime = issuedAtTime.plus(tokenLifetime)
-    return generateJwt(privateKeyId, issuerId, privateKeyFile, issuedAtTime, expirationTime).map { jwtString ->
+    return generateJwt(privateKeyId, issuerId, privateKeyProvider, issuedAtTime, expirationTime).map { jwtString ->
       signedToken = jwtString
     }
   }

--- a/lib/src/main/kotlin/ca/ewert/notarytoolkotlin/authentication/JwtUtil.kt
+++ b/lib/src/main/kotlin/ca/ewert/notarytoolkotlin/authentication/JwtUtil.kt
@@ -15,6 +15,7 @@ import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.nio.file.Path
 import java.security.KeyFactory
+import java.security.interfaces.ECKey
 import java.security.interfaces.ECPrivateKey
 import java.security.spec.EncodedKeySpec
 import java.security.spec.PKCS8EncodedKeySpec
@@ -68,11 +69,11 @@ internal enum class Scope(val scopeValue: String) {
 fun generateJwt(
   privateKeyId: String,
   issuerId: String,
-  privateKeyFile: Path,
+  privateKeyProvider: () -> Result<ECKey, JsonWebTokenError>,
   issuedDate: Instant,
   expiryDate: Instant,
 ): Result<String, JsonWebTokenError> {
-  return createPrivateKey(privateKeyFile).flatMap {
+  return privateKeyProvider().flatMap {
     val algorithm = Algorithm.ECDSA256(it)
     val scopeArray = arrayOf(Scope.GET_SUBMISSIONS.scopeValue)
     try {

--- a/lib/src/main/kotlin/ca/ewert/notarytoolkotlin/authentication/JwtUtil.kt
+++ b/lib/src/main/kotlin/ca/ewert/notarytoolkotlin/authentication/JwtUtil.kt
@@ -15,7 +15,6 @@ import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.nio.file.Path
 import java.security.KeyFactory
-import java.security.interfaces.ECKey
 import java.security.interfaces.ECPrivateKey
 import java.security.spec.EncodedKeySpec
 import java.security.spec.PKCS8EncodedKeySpec
@@ -69,7 +68,7 @@ internal enum class Scope(val scopeValue: String) {
 fun generateJwt(
   privateKeyId: String,
   issuerId: String,
-  privateKeyProvider: () -> Result<ECKey, JsonWebTokenError>,
+  privateKeyProvider: () -> Result<ECPrivateKey, JsonWebTokenError>,
   issuedDate: Instant,
   expiryDate: Instant,
 ): Result<String, JsonWebTokenError> {

--- a/lib/src/test/java/ca/ewert/notarytoolkotlin/examples/java/SubmissionHistoryJ.java
+++ b/lib/src/test/java/ca/ewert/notarytoolkotlin/examples/java/SubmissionHistoryJ.java
@@ -1,13 +1,26 @@
 package ca.ewert.notarytoolkotlin.examples.java;
 
-import java.nio.file.Path;
-import java.time.*;
-import java.time.format.*;
-
-import ca.ewert.notarytoolkotlin.*;
+import ca.ewert.notarytoolkotlin.NotaryToolClient;
+import ca.ewert.notarytoolkotlin.NotaryToolError;
+import ca.ewert.notarytoolkotlin.NotaryToolError.UserInputError.JsonWebTokenError.PrivateKeyNotFoundError;
+import ca.ewert.notarytoolkotlin.TestValuesReader;
 import ca.ewert.notarytoolkotlin.response.SubmissionListResponse;
-
 import com.github.michaelbull.result.Result;
+import com.github.michaelbull.result.ResultKt;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.Base64;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static ca.ewert.notarytoolkotlin.TestUtilKt.resourceToPath;
 
@@ -16,6 +29,14 @@ import static ca.ewert.notarytoolkotlin.TestUtilKt.resourceToPath;
  */
 public class SubmissionHistoryJ {
   public static void main(String[] args) {
+    exampleUsingPrivateKeyFile();
+    exampleUserPrivateKeyProvider();
+  }
+
+  /**
+   * This example uses the private key file Path.
+   */
+  static void exampleUsingPrivateKeyFile() {
     TestValuesReader testValuesReader = new TestValuesReader();
 
     String keyId = testValuesReader.getKeyId$notarytool_kotlin_test();
@@ -50,6 +71,75 @@ public class SubmissionHistoryJ {
           System.out.println("Other Error: " + notaryToolError.getMsg());
         }
       }
+    } else {
+      System.out.printf("Private Key file is null: %s\n", privateKeyFile.toString());
+    }
+  }
+
+  /**
+   * This example uses the private key provider.
+   */
+  static void exampleUserPrivateKeyProvider() {
+    TestValuesReader testValuesReader = new TestValuesReader();
+
+    String keyId = testValuesReader.getKeyId$notarytool_kotlin_test();
+    String issuerId = testValuesReader.getIssueId$notarytool_kotlin_test();
+
+    NotaryToolClient notaryToolClient = new NotaryToolClient(keyId, issuerId, SubmissionHistoryJ::privateKeyProvider,
+        Duration.ofMinutes(10), Duration.ofSeconds(10), "test");
+
+    Result<SubmissionListResponse, NotaryToolError> result = notaryToolClient.getPreviousSubmissions();
+
+    if (result.component1() != null) {
+      SubmissionListResponse submissionListResponse = result.component1();
+      System.out.println("Response Received on: " + DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL)
+          .format(submissionListResponse.getReceivedTimestamp().atZone(ZoneId.systemDefault())));
+      submissionListResponse.getSubmissionInfoList().forEach(submissionInfo -> {
+        System.out.println(submissionInfo.getCreatedDate() + "\t" + submissionInfo.getName()
+            + "\t" + submissionInfo.getId() + "\t" + submissionInfo.getStatus());
+      });
+    } else {
+      NotaryToolError notaryToolError = result.component2();
+
+      if (notaryToolError instanceof NotaryToolError.UserInputError.JsonWebTokenError.AuthenticationError) {
+        System.out.println("Authentication Error: '" + notaryToolError.getMsg() + "' Please check your Apple API " +
+            "Key " +
+            "Credentials");
+      } else if (notaryToolError instanceof NotaryToolError.HttpError) {
+        System.out.println("Http error occurred: " + ((NotaryToolError.HttpError) notaryToolError).getResponseMetaData()
+            .getHttpStatusMessage() + ", " + notaryToolError.getMsg());
+      } else {
+        System.out.println("Other Error: " + notaryToolError.getMsg());
+      }
+    }
+  }
+
+  /**
+   * Creates an ECPrivateKey using a private key file.
+   *
+   * @return an ECPrivateKey or a JsonWebTokenError
+   */
+  static Result<ECPrivateKey, NotaryToolError.UserInputError.JsonWebTokenError> privateKeyProvider() {
+    Path privateKeyFile = resourceToPath("/private/AuthKey_Test.p8");
+    if (privateKeyFile != null && Files.exists(privateKeyFile)) {
+      if (privateKeyFile.toFile().exists()) {
+        try (Stream<String> lines = Files.lines(privateKeyFile)) {
+          byte[] keyBytes = lines
+              .filter(line -> !line.matches("-*\\w+ PRIVATE KEY-*"))
+              .collect(Collectors.joining())
+              .getBytes();
+          byte[] keyBytesBase64Decoded = Base64.getDecoder().decode(keyBytes);
+          PKCS8EncodedKeySpec pkcS8EncodedKeySpec = new PKCS8EncodedKeySpec(keyBytesBase64Decoded);
+          PrivateKey privateKey = KeyFactory.getInstance("EC").generatePrivate(pkcS8EncodedKeySpec);
+          return ResultKt.Ok((ECPrivateKey) privateKey);
+        } catch (Exception exception) {
+          return ResultKt.Err(new NotaryToolError.UserInputError.JsonWebTokenError.InvalidPrivateKeyError(exception.getMessage() != null ? exception.getMessage() : "N/A"));
+        }
+      } else {
+        return ResultKt.Err(new PrivateKeyNotFoundError(privateKeyFile));
+      }
+    } else {
+      return ResultKt.Err(new PrivateKeyNotFoundError(privateKeyFile));
     }
   }
 }

--- a/lib/src/test/kotlin/ca/ewert/notarytoolkotlin/TestUtil.kt
+++ b/lib/src/test/kotlin/ca/ewert/notarytoolkotlin/TestUtil.kt
@@ -1,7 +1,18 @@
 package ca.ewert.notarytoolkotlin
 
+import ca.ewert.notarytoolkotlin.NotaryToolError.UserInputError.JsonWebTokenError
+import ca.ewert.notarytoolkotlin.NotaryToolError.UserInputError.JsonWebTokenError.PrivateKeyNotFoundError
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import java.io.File
 import java.nio.file.Path
+import java.security.KeyFactory
+import java.security.interfaces.ECPrivateKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.*
+import kotlin.io.path.exists
+import kotlin.io.path.useLines
 
 /**
  * Test Utility Functions
@@ -26,4 +37,29 @@ internal fun resourceToFile(resource: String): File? {
  */
 internal fun resourceToPath(resource: String): Path? {
   return object {}.javaClass.getResource(resource)?.toURI()?.let { Path.of(it) }
+}
+
+/**
+ * Convenience class to create an [ECPrivateKey] from a file path.
+ *
+ * @param path path to the private key (`.p8`) file.
+ */
+internal fun privateKeyFromPath(path: Path): Result<ECPrivateKey, JsonWebTokenError> {
+  return if (path.exists()) {
+    val keyBytes = path.useLines { lines ->
+      lines.filter { !it.matches(Regex("-*\\w+ PRIVATE KEY-*")) }.joinToString(separator = "").toByteArray()
+    }
+    try {
+      val keyBytesBase64Decoded: ByteArray = Base64.getDecoder().decode(keyBytes)
+      val pkcS8EncodedKeySpec = PKCS8EncodedKeySpec(keyBytesBase64Decoded)
+      Ok(KeyFactory.getInstance("EC").generatePrivate(pkcS8EncodedKeySpec) as ECPrivateKey)
+    } catch (exception: Exception) {
+      Err(
+        JsonWebTokenError
+          .InvalidPrivateKeyError(exceptionMsg = exception.message ?: "N/A"),
+      )
+    }
+  } else {
+    Err(PrivateKeyNotFoundError(path))
+  }
 }

--- a/lib/src/test/kotlin/ca/ewert/notarytoolkotlin/authentication/JsonWebTokenTest.kt
+++ b/lib/src/test/kotlin/ca/ewert/notarytoolkotlin/authentication/JsonWebTokenTest.kt
@@ -8,6 +8,7 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
 import ca.ewert.notarytoolkotlin.isCloseTo
 import ca.ewert.notarytoolkotlin.isOk
+import ca.ewert.notarytoolkotlin.privateKeyFromPath
 import ca.ewert.notarytoolkotlin.resourceToPath
 import com.github.michaelbull.result.onSuccess
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -58,7 +59,7 @@ class JsonWebTokenTest {
     val jsonWebTokenResult = JsonWebToken.create(
       privateKeyId = "ABCDEFG",
       issuerId = "1234567",
-      privateKeyFile = privateKeyFile!!,
+      privateKeyProvider = { privateKeyFromPath(privateKeyFile!!) },
       tokenLifetime = tokenLifetime,
     )
     assertThat(jsonWebTokenResult).isOk()
@@ -112,7 +113,7 @@ class JsonWebTokenTest {
     val jsonWebTokenResult = JsonWebToken.create(
       privateKeyId = "ABCDEFG",
       issuerId = "1234567",
-      privateKeyFile = privateKeyFile!!,
+      privateKeyProvider = { privateKeyFromPath(privateKeyFile!!) },
       tokenLifetime = tokenLifetime,
     )
 
@@ -146,7 +147,7 @@ class JsonWebTokenTest {
     val jsonWebTokenResult = JsonWebToken.create(
       privateKeyId = "ABCDEFG",
       issuerId = "1234567",
-      privateKeyFile = privateKeyFile!!,
+      privateKeyProvider = { privateKeyFromPath(privateKeyFile!!) },
       tokenLifetime = tokenLifetime,
     )
 

--- a/lib/src/test/kotlin/ca/ewert/notarytoolkotlin/authentication/JwtGenerator.kt
+++ b/lib/src/test/kotlin/ca/ewert/notarytoolkotlin/authentication/JwtGenerator.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isNotNull
 import ca.ewert.notarytoolkotlin.TestValuesReader
 import ca.ewert.notarytoolkotlin.isOk
+import ca.ewert.notarytoolkotlin.privateKeyFromPath
 import ca.ewert.notarytoolkotlin.resourceToPath
 import com.github.michaelbull.result.onSuccess
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -42,7 +43,7 @@ class JwtGenerator {
       val generateJwtResult = generateJwt(
         keyId,
         issuerId,
-        privateKeyFile,
+        privateKeyProvider = { privateKeyFromPath(privateKeyFile) },
         Instant.now(),
         Instant.now().plus(Duration.ofMinutes(15)),
       )

--- a/lib/src/test/kotlin/ca/ewert/notarytoolkotlin/authentication/JwtUtilTests.kt
+++ b/lib/src/test/kotlin/ca/ewert/notarytoolkotlin/authentication/JwtUtilTests.kt
@@ -13,6 +13,7 @@ import ca.ewert.notarytoolkotlin.NotaryToolError.UserInputError.JsonWebTokenErro
 import ca.ewert.notarytoolkotlin.isErrAnd
 import ca.ewert.notarytoolkotlin.isOkAnd
 import ca.ewert.notarytoolkotlin.messageContainsMatch
+import ca.ewert.notarytoolkotlin.privateKeyFromPath
 import ca.ewert.notarytoolkotlin.resourceToPath
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
@@ -51,7 +52,7 @@ class JwtUtilTests {
     val generateJwtResult = generateJwt(
       privateKeyId = "ABCDE12345",
       issuerId = "70c5de5f-f737-47e2-e043-5b8c7c22a4d9",
-      privateKeyFile = privateKeyFile!!,
+      privateKeyProvider = { privateKeyFromPath(privateKeyFile!!) },
       issuedDate.toInstant(),
       expiryDate.toInstant(),
     )
@@ -102,7 +103,7 @@ class JwtUtilTests {
     val generateJwtResult = generateJwt(
       privateKeyId = "ABCDE12345",
       issuerId = "70c5de5f-f737-47e2-e043-5b8c7c22a4d9",
-      privateKeyFile = privateKeyFile,
+      privateKeyProvider = { privateKeyFromPath(privateKeyFile) },
       issuedDate.toInstant(),
       expiryDate.toInstant(),
     )
@@ -129,7 +130,7 @@ class JwtUtilTests {
     val generateJwtResult = generateJwt(
       privateKeyId = "",
       issuerId = "",
-      privateKeyFile = privateKeyFile!!,
+      privateKeyProvider = { privateKeyFromPath(privateKeyFile!!) },
       issuedDate.toInstant(),
       expiryDate.toInstant(),
     )
@@ -180,7 +181,7 @@ class JwtUtilTests {
     val generateJwtResult = generateJwt(
       privateKeyId = "ABCDE12345",
       issuerId = "70c5de5f-f737-47e2-e043-5b8c7c22a4d9",
-      privateKeyFile = privateKeyFile!!,
+      privateKeyProvider = { privateKeyFromPath(privateKeyFile!!) },
       issuedDate.toInstant(),
       expiryDate.toInstant(),
     )
@@ -209,7 +210,7 @@ class JwtUtilTests {
     val generateJwtResult = generateJwt(
       privateKeyId = "ABCDE12345",
       issuerId = "70c5de5f-f737-47e2-e043-5b8c7c22a4d9",
-      privateKeyFile = privateKeyFile!!,
+      privateKeyProvider = { privateKeyFromPath(privateKeyFile!!) },
       issuedDate.toInstant(),
       expiryDate.toInstant(),
     )
@@ -238,7 +239,7 @@ class JwtUtilTests {
     val generateJwtResult = generateJwt(
       privateKeyId = "ABCDE12345",
       issuerId = "70c5de5f-f737-47e2-e043-5b8c7c22a4d9",
-      privateKeyFile = privateKeyFile!!,
+      privateKeyProvider = { privateKeyFromPath(privateKeyFile!!) },
       issuedDate.toInstant(),
       expiryDate.toInstant(),
     )
@@ -267,7 +268,7 @@ class JwtUtilTests {
     val generateJwtResult = generateJwt(
       privateKeyId = "ABCDE12345",
       issuerId = "70c5de5f-f737-47e2-e043-5b8c7c22a4d9",
-      privateKeyFile = privateKeyFile!!,
+      privateKeyProvider = { privateKeyFromPath(privateKeyFile!!) },
       issuedDate.toInstant(),
       expiryDate.toInstant(),
     )

--- a/lib/src/test/kotlin/ca/ewert/notarytoolkotlin/examples/kotlin/SubmissionHistory.kt
+++ b/lib/src/test/kotlin/ca/ewert/notarytoolkotlin/examples/kotlin/SubmissionHistory.kt
@@ -2,13 +2,24 @@ package ca.ewert.notarytoolkotlin.examples.kotlin
 
 import ca.ewert.notarytoolkotlin.NotaryToolClient
 import ca.ewert.notarytoolkotlin.NotaryToolError
+import ca.ewert.notarytoolkotlin.NotaryToolError.UserInputError.JsonWebTokenError
+import ca.ewert.notarytoolkotlin.NotaryToolError.UserInputError.JsonWebTokenError.PrivateKeyNotFoundError
 import ca.ewert.notarytoolkotlin.TestValuesReader
 import ca.ewert.notarytoolkotlin.resourceToPath
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.nio.file.Path
+import java.security.KeyFactory
+import java.security.interfaces.ECPrivateKey
+import java.security.spec.PKCS8EncodedKeySpec
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
+import java.util.*
+import kotlin.io.path.exists
+import kotlin.io.path.useLines
 
 private val log = KotlinLogging.logger {}
 
@@ -16,6 +27,14 @@ private val log = KotlinLogging.logger {}
  * Example of getting the Submission History
  */
 fun main() {
+  exampleUsingPrivateKeyPath()
+  exampleUsingPrivateKeyProvider()
+}
+
+/**
+ * This example uses the private key file Path.
+ */
+private fun exampleUsingPrivateKeyPath() {
   val testValuesReader = TestValuesReader()
   val keyId: String = testValuesReader.getKeyId()
   val issuerId: String = testValuesReader.getIssueId()
@@ -62,5 +81,80 @@ fun main() {
     }
   } else {
     log.warn { "Can't get private key file" }
+  }
+}
+
+/**
+ * This example uses the private key provider.
+ */
+private fun exampleUsingPrivateKeyProvider() {
+  val testValuesReader = TestValuesReader()
+  val keyId: String = testValuesReader.getKeyId()
+  val issuerId: String = testValuesReader.getIssueId()
+  val privateKeyFile: Path? = resourceToPath("/private/AuthKey_Test.p8")
+
+  val notaryToolClient = NotaryToolClient(
+    privateKeyId = keyId,
+    issuerId = issuerId,
+    privateKeyProvider = ::privateKeyProvider, // privateKeyProvider is a function that creates an ECPrivateKey
+  )
+
+  println("Token Lifetime: ${notaryToolClient.tokenLifetime}")
+  println("Connect Timeout: ${notaryToolClient.connectTimeout}")
+  println(notaryToolClient.userAgent)
+
+  val result = notaryToolClient.getPreviousSubmissions()
+  when {
+    result.isOk -> {
+      val submissionListResponse = result.value
+      println(
+        "Response Received on: ${
+          DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL, FormatStyle.LONG)
+            .format(submissionListResponse.receivedTimestamp.atZone(ZoneId.systemDefault()))
+        }",
+      )
+      println("Response Status: ${submissionListResponse.responseMetaData.httpStatusString}")
+      submissionListResponse.submissionInfoList.forEach { submissionInfo ->
+        println("${submissionInfo.createdDate}\t${submissionInfo.id}\t${submissionInfo.status}\t${submissionInfo.name}")
+      }
+    }
+
+    else -> {
+      when (val notaryToolError = result.error) {
+        is NotaryToolError.UserInputError.AuthenticationError ->
+          println("Authentication Error: '${notaryToolError.msg}' Please check your Apple API Key credentials")
+
+        is NotaryToolError.HttpError ->
+          println("Http error occurred: ${notaryToolError.responseMetaData.httpStatusCode}, ${notaryToolError.msg}")
+
+        else -> println("Other error: ${notaryToolError.msg}")
+      }
+    }
+  }
+}
+
+/**
+ * Creates an ECPrivateKey using a private key file.
+ *
+ * @return an ECPrivateKey or a JsonWebTokenError
+ */
+internal fun privateKeyProvider(): Result<ECPrivateKey, JsonWebTokenError> {
+  val privateKeyFile: Path? = resourceToPath("/private/AuthKey_Test.p8")
+  return if (privateKeyFile!!.exists()) {
+    val keyBytes: ByteArray = privateKeyFile.useLines { lines ->
+      lines.filter { !it.matches(Regex("-*\\w+ PRIVATE KEY-*")) }.joinToString(separator = "").toByteArray()
+    }
+    try {
+      val keyBytesBase64Decoded: ByteArray = Base64.getDecoder().decode(keyBytes)
+      val pkcS8EncodedKeySpec = PKCS8EncodedKeySpec(keyBytesBase64Decoded)
+      Ok(KeyFactory.getInstance("EC").generatePrivate(pkcS8EncodedKeySpec) as ECPrivateKey)
+    } catch (exception: Exception) {
+      Err(
+        JsonWebTokenError
+          .InvalidPrivateKeyError(exceptionMsg = exception.message ?: "N/A"),
+      )
+    }
+  } else {
+    Err(PrivateKeyNotFoundError(privateKeyFile))
   }
 }


### PR DESCRIPTION
Closes #3

Adds an alternate constructor to `NotaryToolClient` that accepts a 'supplier' function that generates an `ECPrivateKey`.